### PR TITLE
Fix python-crane version in new packaging repo

### DIFF
--- a/packages/python-crane/python-crane.spec
+++ b/packages/python-crane/python-crane.spec
@@ -5,7 +5,7 @@
 %endif
 
 Name: python-crane
-Version: 2.2.0
+Version: 3.2.0
 Release: 0.1.alpha%{?dist}
 Summary: docker-registry-like API with redirection, as a wsgi app
 


### PR DESCRIPTION
Fix python-crane version in new packaging repo