### PR TITLE
Adding a patch to django for FIPS compatibility

### DIFF
--- a/packages/python-django/Django-1.11.11.tar.gz
+++ b/packages/python-django/Django-1.11.11.tar.gz
@@ -1,1 +1,0 @@
-../../.git/annex/objects/Kk/6F/SHA256E-s7961491--74077d7309b48b97dacdac2dfb35c968028becf00a7a684e7f29b2af1b980edc.tar.gz/SHA256E-s7961491--74077d7309b48b97dacdac2dfb35c968028becf00a7a684e7f29b2af1b980edc.tar.gz

--- a/packages/python-django/Django-1.11.13.tar.gz
+++ b/packages/python-django/Django-1.11.13.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/W4/9x/SHA256E-s7884529--46adfe8e0abe4d1f026c1086889970b611aec492784fbdfbdaabc2457360a4a5.tar.gz/SHA256E-s7884529--46adfe8e0abe4d1f026c1086889970b611aec492784fbdfbdaabc2457360a4a5.tar.gz

--- a/packages/python-django/fips.patch
+++ b/packages/python-django/fips.patch
@@ -1,0 +1,28 @@
+diff --git a/django/utils/cache.py b/django/utils/cache.py
+index 0f6232b51b..73f496e0f9 100644
+--- a/django/utils/cache.py
++++ b/django/utils/cache.py
+@@ -19,6 +19,7 @@ An example: i18n middleware would need to distinguish caches by the
+ from __future__ import unicode_literals
+ 
+ import hashlib
++import inspect
+ import logging
+ import re
+ import time
+@@ -106,7 +107,16 @@ def get_max_age(response):
+ 
+ def set_response_etag(response):
+     if not response.streaming:
+-        response['ETag'] = quote_etag(hashlib.md5(response.content).hexdigest())
++        try:
++            md5_hash = hashlib.md5(response.content)
++        except ValueError as e:
++            if 'usedforsecurity' in inspect.getargspec(hashlib.new)[0]:
++                md5_hash = hashlib.md5(response.content, usedforsecurity=False)
++            else:
++                raise e
++
++        response['ETag'] = quote_etag(md5_hash.hexdigest())
++
+     return response

--- a/packages/python-django/python-django.spec
+++ b/packages/python-django/python-django.spec
@@ -8,11 +8,11 @@
 
 # one higher than the last Django release, to account for
 # dist tags
-%global         obs_ver 1.11.11-1
+%global         obs_ver 1.11.13-1
 
 Name:           python-django
 
-Version:        1.11.11
+Version:        1.11.13
 Release:        1%{?dist}
 Summary:        A high-level Python Web framework
 
@@ -20,6 +20,9 @@ Group:          Development/Languages
 License:        BSD
 URL:            http://www.djangoproject.com/
 Source0:        https://files.pythonhosted.org/packages/source/D/Django/Django-%{version}.tar.gz
+
+# patch to make django work in fips environment
+Patch0:         fips.patch
 
 
 BuildArch:      noarch
@@ -54,7 +57,7 @@ principle.
 
 
 %prep
-%autosetup -n %{pkgname}-%{version}
+%autosetup -n %{pkgname}-%{version} -p1
 
 %build
 %{__python} setup.py build


### PR DESCRIPTION
Also, bumping the django version to the latest 1.11.z release.

fixes #3639
https://pulp.plan.io/issues/3639