### PR TITLE
Python2-solv required for depsolving

### DIFF
--- a/packages/pulp-rpm/pulp-rpm.spec
+++ b/packages/pulp-rpm/pulp-rpm.spec
@@ -205,6 +205,7 @@ Requires: rsync
 Requires: deltarpm
 Requires: python-deltarpm
 Requires: libmodulemd >= 1.4.0
+Requires: python2-solv >= 0.6.34-3
 
 %description plugins
 Provides a collection of platform plugins that extend the Pulp platform


### PR DESCRIPTION
The Pulp RPM plugin switches depsolving implementation to a libsolv-based
one[1].  This patch adds a dependency on the python2 libsolv bindings that
include necessary functionality, esp. the file-provides Python libsolv
API.

[1] https://github.com/pulp/pulp_rpm/pull/1122