### PR TITLE
Temporarily revert python-solv requirement

### DIFF
--- a/packages/pulp-rpm/pulp-rpm.spec
+++ b/packages/pulp-rpm/pulp-rpm.spec
@@ -205,7 +205,6 @@ Requires: rsync
 Requires: deltarpm
 Requires: python-deltarpm
 Requires: libmodulemd >= 1.4.0
-Requires: python2-solv >= 0.6.34-3
 
 %description plugins
 Provides a collection of platform plugins that extend the Pulp platform


### PR DESCRIPTION
This requirement is causing RHEL builds to fail. Resolve it until we can open a PR to carry this dependency ourselves.