### PR TITLE
Keep the post transaction output clean from selinux output

### DIFF
--- a/packages/python-crane/python-crane.spec
+++ b/packages/python-crane/python-crane.spec
@@ -71,8 +71,8 @@ rm -rf %{buildroot}%{python2_sitelib}/tests
 %post
 if /usr/sbin/selinuxenabled ; then
   if [ -d "%{_var}/lib/crane" ]; then
-    semanage fcontext -a -t httpd_sys_content_t '%{_var}/lib/crane(/.*)?'
-    restorecon -R -v %{_var}/lib/crane
+    semanage fcontext -a -t httpd_sys_content_t '%{_var}/lib/crane(/.*)?' >/dev/null 2>&1 || :
+    restorecon -R -v %{_var}/lib/crane  >/dev/null 2>&1 || :
   fi
 fi
 
@@ -80,8 +80,8 @@ fi
 if [ $1 -eq 0 ] ; then  # final removal
   if /usr/sbin/selinuxenabled ; then
     if [ -d "%{_var}/lib/crane" ]; then
-      semanage fcontext -d -t httpd_sys_content_t '%{_var}/lib/crane(/.*)?'
-      restorecon -R -v %{_var}/lib/crane
+      semanage fcontext -d -t httpd_sys_content_t '%{_var}/lib/crane(/.*)?' >/dev/null 2>&1 || :
+      restorecon -R -v %{_var}/lib/crane >/dev/null 2>&1 || :
     fi
   fi
 fi


### PR DESCRIPTION
I've noticed when installing katello rpms the following stdout:

    restorecon reset /var/lib/crane/metadata context system_u:object_r:va
    _lib_t:s0->system_u:object_r:httpd_sys_content_t:s0

Since other commands usually don't produced anything to stdout in post section,
it looked suspicious. I think keeping it quiet would avoid some unnecessary
user panic during the installation.

Note that we are suppressing the restorecon output even more in the tfm package:

https://github.com/theforeman/foreman-packaging/blob/ac8c318fde603ab058c7e7540a4c254d9871c161/packages/foreman/tfm/tfm.spec#L275