### PR TITLE
Ensure celery dependency conflicts properly

### DIFF
--- a/packages/pulp/pulp.spec
+++ b/packages/pulp/pulp.spec
@@ -381,7 +381,9 @@ Requires: pulp-selinux
 Requires: python-%{name}-common = %{pulp_version}
 Requires: python-%{name}-repoauth = %{pulp_version}
 Requires: python-blinker
-Requires: python-celery >= 4.0.0
+Requires: python2-celery >= 4.0.0
+Requires: python2-celery < 4.1
+Conflicts: python2-celery >= 4.1
 Requires: python-pymongo >= 3.0.0
 Requires: python-mongoengine >= 0.10.0
 Requires: python-setuptools

--- a/packages/python-amqp/python-amqp.spec
+++ b/packages/python-amqp/python-amqp.spec
@@ -2,7 +2,7 @@
 
 Name:           python-%{srcname}
 Version:        2.2.2
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Low-level AMQP client for Python (fork of amqplib)
 
 Group:          Development/Languages
@@ -22,6 +22,8 @@ This library should be API compatible with librabbitmq.
 %package -n python2-%{srcname}
 Summary:     Client library for AMQP
 Requires:    python2-vine >= 1.1.3
+Requires:    python2-vine < 1.2
+Conflicts:   python2-vine >= 1.2
 BuildRequires:  python2-devel
 BuildRequires:  python-setuptools
 BuildRequires:  python-nose
@@ -69,6 +71,9 @@ Documentation for python-amqp
 %license LICENSE
 
 %changelog
+* Tue Feb 19 2019 Patrick Creech <pcreech@redhat.com> - 2.2.2-4
+- rebuilt
+
 * Tue Jan 16 2018 Patrick Creech <pcreech@redhat.com> - 2.2.2-3
 - Fix obsoletes for 2.2.2
 

--- a/packages/python-celery/python-celery.spec
+++ b/packages/python-celery/python-celery.spec
@@ -21,7 +21,7 @@ for Redis, Beanstalk, MongoDB, CouchDB and databases\
 
 Name:           python-celery
 Version:        4.0.2
-Release:        5%{?dist}
+Release:        6%{?dist}
 BuildArch:      noarch
 
 License:        BSD
@@ -52,7 +52,9 @@ Obsoletes:      python-celery < %{version}
 Requires:       python-amqp
 Requires:       python-anyjson
 Requires:       python-billiard >= 1:3.3.0.22
-Requires:       python-kombu >= 1:3.0.33
+Requires:       python2-kombu >= 1:3.0.33
+Requires:       python2-kombu < 1:4.1
+Conflicts:      python2-kombu >= 1:4.1
 Requires:       python2-setuptools
 Requires:       pytz
 
@@ -67,7 +69,7 @@ BuildRequires:  python-setuptools
 
 
 %prep
-%autosetup -n celery-%{version}
+%autosetup -n celery-%{version} -p1
 
 
 %build
@@ -97,6 +99,9 @@ BuildRequires:  python-setuptools
 
 
 %changelog
+* Mon Feb 18 2019 Patrick Creech <pcreech@redhat.com> - 4.0.2-6
+- rebuilt
+
 * Wed Jul 25 2018 Daniel Alley <dalley@redhat.com> - 4.0.2-5
 - Added a patch to fix Celery issue https://github.com/celery/celery/issues/3620
 

--- a/packages/python-kombu/python-kombu.spec
+++ b/packages/python-kombu/python-kombu.spec
@@ -2,7 +2,7 @@
 
 Name:           python-%{srcname}
 Version:        4.0.2
-Release:        9%{?dist}
+Release:        10%{?dist}
 Epoch:          1
 Summary:        An AMQP Messaging Framework for Python
 
@@ -49,7 +49,9 @@ also provide proven and tested solutions to common messaging problems.
 
 %package -n python2-%{srcname}
 Summary:        %{sum}
-Requires:       python-amqp >= 2.1.4
+Requires:       python2-amqp >= 2.1.4
+Requires:       python2-amqp < 2.3
+Conflicts:      python2-amqp >= 2.3
 Requires:       python2-vine
 Provides:       python-%{srcname}
 Obsoletes:      python-%{srcname} < 1:%{version}
@@ -80,6 +82,9 @@ also provide proven and tested solutions to common messaging problems.
 %{python2_sitelib}/%{srcname}*.egg-info
 
 %changelog
+* Tue Feb 19 2019 Patrick Creech <pcreech@redhat.com> - 1:4.0.2-10
+- rebuilt
+
 * Fri May 18 2018 Daniel Alley <dalley@redhat.com> - 1:4.0.2-9
 - Make kombu FIPS compatible
 


### PR DESCRIPTION
This is to help prevent updated celery from being installed on pulp servers.