### PR TITLE
Use the python2 package names

### DIFF
--- a/packages/python-celery/python-celery.spec
+++ b/packages/python-celery/python-celery.spec
@@ -49,9 +49,9 @@ Summary:        Distributed Task Queue
 Provides:       python-celery
 Obsoletes:      python-celery < %{version}
 
-Requires:       python-amqp
+Requires:       python2-amqp
 Requires:       python-anyjson
-Requires:       python-billiard >= 1:3.3.0.22
+Requires:       python2-billiard >= 1:3.3.0.22
 Requires:       python2-kombu >= 1:3.0.33
 Requires:       python2-kombu < 1:4.1
 Conflicts:      python2-kombu >= 1:4.1


### PR DESCRIPTION
While python2-amqp provides python-amqp, this is the more direct dependency that's also available. The same goes for python2-billiard.