### PR TITLE
Problem: chown command is run for all upgrades

### DIFF
--- a/packages/pulp/pulp.spec
+++ b/packages/pulp/pulp.spec
@@ -509,7 +509,9 @@ if [ $1 -gt 1 ] ; then
         /sbin/service pulp_celerybeat stop > /dev/null 2>&1 || :
         /sbin/service pulp_resource_manager stop > /dev/null 2>&1 || :
     %endif
-    /usr/bin/chown -R apache:pulp /var/lib/pulp
+    if [ $(stat -c '%U:%G' /var/lib/pulp) != 'apache:pulp' ] ; then
+        /usr/bin/chown -R apache:pulp /var/lib/pulp
+    fi
 fi
 
 %preun server


### PR DESCRIPTION
Solution: only run chown if ownership permissions are not apache:pulp

re: #4948
https://pulp.plan.io/issues/4948
re: #4949
https://pulp.plan.io/issues/4949