### PR TITLE
Problem: Pulp 3 can't sync when installed along side Pulp 2

### DIFF
--- a/packages/pulp/pulp.spec
+++ b/packages/pulp/pulp.spec
@@ -481,7 +481,7 @@ Pulp provides replication, access, and accounting for software repositories.
 %ghost %{_sysconfdir}/pki/%{name}/rsa_pub.key
 %config(noreplace) %{_sysconfdir}/%{name}/server.conf
 # - apache:pulp
-%defattr(-,apache,pulp,-)
+%defattr(-,apache,pulp,775)
 %dir %{_var}/lib/%{name}
 %{_var}/lib/%{name}/published
 %{_var}/lib/%{name}/static

--- a/packages/pulp/pulp.spec
+++ b/packages/pulp/pulp.spec
@@ -509,9 +509,6 @@ if [ $1 -gt 1 ] ; then
         /sbin/service pulp_celerybeat stop > /dev/null 2>&1 || :
         /sbin/service pulp_resource_manager stop > /dev/null 2>&1 || :
     %endif
-    if [ $(stat -c '%U:%G' /var/lib/pulp) != 'apache:pulp' ] ; then
-        /usr/bin/chown -R apache:pulp /var/lib/pulp
-    fi
 fi
 
 %preun server


### PR DESCRIPTION
Solution: make /var/lib/pulp writable by group 'pulp'

This patch also removes the recursive chown for /var/lib/pulp.

fixes: #5152
https://pulp.plan.io/issues/5152