### PR TITLE
patch pulp_rpm with https://pulp.plan.io/issues/7849

### DIFF
--- a/packages/pulp-rpm/0001-Revert-mkdir-changes-for-pulp_rpm.handlers.repo_file.patch
+++ b/packages/pulp-rpm/0001-Revert-mkdir-changes-for-pulp_rpm.handlers.repo_file.patch
@@ -1,0 +1,55 @@
+From c4b1c29eed96895455464a4e5e9e8a9f289d6938 Mon Sep 17 00:00:00 2001
+From: Grant Gainey <ggainey@redhat.com>
+Date: Wed, 18 Nov 2020 11:21:33 -0500
+Subject: [PATCH] Revert mkdir() changes for pulp_rpm.handlers.repo_file.Repo
+ and CertFiles.
+
+fixes #7849
+---
+ handlers/pulp_rpm/handlers/repo_file.py | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git handlers/pulp_rpm/handlers/repo_file.py handlers/pulp_rpm/handlers/repo_file.py
+index 78a7ba52..f79af1ff 100644
+--- handlers/pulp_rpm/handlers/repo_file.py
++++ handlers/pulp_rpm/handlers/repo_file.py
+@@ -3,7 +3,6 @@ import shutil
+ 
+ from iniparse import ConfigParser
+ from pulp.common.util import encode_unicode
+-from pulp.plugins.util import misc
+ 
+ 
+ class Repo(dict):
+@@ -410,7 +409,7 @@ class RepoKeyFiles(object):
+         # If there are any keys to write, create the directory for the repo's keys
+         # and write each of them out
+         if len(self.keys) > 0:
+-            misc.mkdir(self.repo_keys_dir)
++            os.makedirs(self.repo_keys_dir)
+ 
+             for filename in self.keys:
+                 f = open(filename, 'w')
+@@ -460,7 +459,7 @@ class CertFiles(object):
+         if not self.clientcert:
+             return None
+ 
+-        misc.mkdir(self.rootdir)
++        self.__mkdir()
+         path = os.path.join(self.rootdir, self.CLIENT)
+         f = open(path, 'w')
+         f.write(self.clientcert)
+@@ -470,6 +469,10 @@ class CertFiles(object):
+     def __nocerts(self):
+         return not self.clientcert
+ 
++    def __mkdir(self):
++        if not os.path.exists(self.rootdir):
++            os.makedirs(self.rootdir)
++
+     def __clear(self):
+         if os.path.exists(self.rootdir):
+             shutil.rmtree(self.rootdir)
+-- 
+2.28.0
+

--- a/packages/pulp-rpm/pulp-rpm.spec
+++ b/packages/pulp-rpm/pulp-rpm.spec
@@ -23,12 +23,13 @@
 # ---- Pulp (rpm) --------------------------------------------------------------
 Name: pulp-rpm
 Version: 2.21.4
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Support for RPM content in the Pulp platform
 Group: Development/Languages
 License: GPLv2
 URL: http://pulpproject.org/
 Source0: https://github.com/pulp/%{srcname}/archive/%{git_tag}/%{srcname}-%{git_tag}.tar.gz
+Patch0: 0001-Revert-mkdir-changes-for-pulp_rpm.handlers.repo_file.patch
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
 %if 0%{?suse_version}
@@ -45,6 +46,7 @@ handlers that provide RPM support.
 
 %prep
 %setup -q -n %{srcname}-%{git_tag}
+%patch0 -p0
 
 %build
 
@@ -383,6 +385,9 @@ A fsck-like tool to generate Pulp integrity report
 %endif
 
 %changelog
+* Thu Nov 19 2020 Evgeni Golov - 2.21.4-2
+- Add patch for https://pulp.plan.io/issues/7849
+
 * Tue Nov 03 2020 Evgeni Golov - 2.21.4-1
 - 2.21.4 GA
 


### PR DESCRIPTION
scratch builds:

  - el7: http://koji.katello.org/koji/taskinfo?taskID=384668
  - fc28: http://koji.katello.org/koji/taskinfo?taskID=384669
  - el5: http://koji.katello.org/koji/taskinfo?taskID=384671
  - el6: http://koji.katello.org/koji/taskinfo?taskID=384673

EL5 failed because I'm on Fedora and SRPMs generated here don't work on EL5 -- will fix for the real release